### PR TITLE
Add a import bpy statement to the sphere example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Some frequently used functions in blender, which will be used in most of the scr
 Simple rendering of a smooth sphere. First an icosphere is added with
 
 ```python
+import bpy
 bpy.ops.mesh.primitive_ico_sphere_add(location=(0, 0, 0))
 obj = bpy.context.object
 ```


### PR DESCRIPTION
This makes it so that copy-pasting the sphere sample works with an empty Python editor in Blender. The other linked files are all working files, so there's no problem there, but the sphere inline script was the only one a bit incomplete. The error message in Blender sucks, it took a while for me to figure out why simple statements like these weren't working in the editor but were working in the console, so hopefully this will save someone else a bit of time.