### PR TITLE
It's need to import os to use function from os (In python 3.5.1 with …

### DIFF
--- a/scripts/fisher_iris_visualization.py
+++ b/scripts/fisher_iris_visualization.py
@@ -4,7 +4,7 @@ import numpy as np
 import utils
 from mathutils import Vector, Matrix
 from math import pi
-
+import os
 
 def PCA(data, num_components=None):
     # mean center the data


### PR DESCRIPTION
Thanks a lot for your sharing a lot of good code in this nice project. :D 
It is need to import os to use function from os (os.path.join).
So after import os, the code can work. 

I use python 3.5.1 in blender 2.77 

![Screen Shot 2019-09-27 at 2 24 10 PM](https://user-images.githubusercontent.com/12568287/65747748-c7507a80-e134-11e9-8c31-02c98bb2ba56.png)
…blender 2.77)