### PR TITLE
Fixed the issue of https://github.com/njanakiev/blender-scripting/iss…

### DIFF
--- a/scripts/fisher_iris_visualization.py
+++ b/scripts/fisher_iris_visualization.py
@@ -125,8 +125,7 @@ def createLabels(X, y, labels, cameraObj=None):
         label = labels[labelIdx]
         fontCurve = bpy.data.curves.new(type="FONT", name=label)
         fontCurve.body = label
-        fontCurve.align_x = 'CENTER'
-        fontCurve.align_y = 'BOTTOM'
+        fontCurve.align = 'CENTER'
         fontCurve.size = 0.6
 
         obj = bpy.data.objects.new("Label {}".format(label), fontCurve)


### PR DESCRIPTION
The is issue here here
https://github.com/njanakiev/blender-scripting/issues/3

In older version, 2.77_1 blender support align_x and align_y for TextCurve
But in the released version 2.77, it only has align. 

The following two hyperlink show the difference from view of API document
https://docs.blender.org/api/blender_python_api_2_77_1/bpy.types.TextCurve.html
https://docs.blender.org/api/blender_python_api_2_77_release/bpy.types.TextCurve.html

So I just set align = 'CENTER'. 